### PR TITLE
Fix: remove undefined post_process() call in sampling mode

### DIFF
--- a/scheduler/scheduler.py
+++ b/scheduler/scheduler.py
@@ -176,8 +176,6 @@ class Scheduler:
                             len(self.active_processes) == 0 and 
                             pending_machines == 0)
                 if all_ended and all_satisfied:
-                    if self.mode == "sampling":
-                        self.post_process()
                     if break_on_complete:
                         print("All tasks completed.")
                         break


### PR DESCRIPTION
## Summary
This PR fixes a crash at the end of the construction pipeline when running in `mode == "sampling"`.

`Scheduler.run()` still calls `self.post_process()`, but `post_process()` was removed during a refactor (sampling and data cleanup/analysis were split). The leftover call raises:
`AttributeError: 'Scheduler' object has no attribute 'post_process'`

## Behavior / Impact
- **Sampling itself is unaffected**: machines are still generated and outputs are produced normally.
- The error only triggers **after sampling finishes**, at the very end of the run.

## Changes
- Remove the stale `post_process()` invocation in `scheduler/scheduler.py` for sampling mode.

## Notes
The old `post_process()` was for internal experiment analysis and is not part of the intended public pipeline. Aggregation/selection across samples is left to downstream evaluation scripts for now.

Fixes #2